### PR TITLE
refactor: Convert to pure SwiftUI architecture without UIKit/AppKit dependencies

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Brixie AI Coding Agent Guide
 
-Brixie is a **pure SwiftUI** multi-platform app for browsing LEGO sets via the Rebrickable API. It targets iOS 17+, macOS 14+ (Catalyst), and visionOS 1+, using Swift 6+ concurrency and SwiftData for persistence. The codebase is organized for clarity and maintainability.
+Brixie is a **pure SwiftUI** multi-platform app for browsing LEGO sets via the Rebrickable API. It targets iOS 26+, macOS 26+ (Catalyst), and visionOS 26+, using Swift 6+ concurrency and SwiftData for persistence. The codebase is organized for clarity and maintainability.
 
 **CRITICAL: SwiftUI-Only Architecture**
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,15 @@
 
 ## Brixie AI Coding Agent Guide
 
-Brixie is a multi-platform SwiftUI app for browsing LEGO sets via the Rebrickable API. It targets iOS 26+, macOS 26+ (Catalyst), and visionOS, using Swift 6+ concurrency and SwiftData for persistence. The codebase is organized for clarity and maintainability.
+Brixie is a **pure SwiftUI** multi-platform app for browsing LEGO sets via the Rebrickable API. It targets iOS 17+, macOS 14+ (Catalyst), and visionOS 1+, using Swift 6+ concurrency and SwiftData for persistence. The codebase is organized for clarity and maintainability.
+
+**CRITICAL: SwiftUI-Only Architecture**
+
+- **NO UIKit or AppKit dependencies** - Use only SwiftUI primitives and cross-platform APIs
+- Use `@Environment(\.horizontalSizeClass)` instead of `UIDevice` for device detection
+- Use SwiftUI's native sharing via `ShareLink` instead of `UIActivityViewController`
+- All UI components must be pure SwiftUI - no platform-specific wrappers
+- Image loading uses SwiftUI's `AsyncImage` or custom SwiftUI-based solutions
 
 ### Architecture Overview
 
@@ -29,6 +37,13 @@ Brixie is a multi-platform SwiftUI app for browsing LEGO sets via the Rebrickabl
 - **Branch-Based Config:** Debug for feature/develop branches, Release for main/release/hotfix branches.
 
 ### Key Conventions & Patterns
+
+- **SwiftUI-Only Architecture:**
+
+  - NO UIKit/AppKit imports or dependencies
+  - Use SwiftUI's environment values for device detection
+  - Platform-specific behavior via SwiftUI modifiers and environment
+  - Pure SwiftUI image loading and caching solutions
 
 - **API Key Management:**
   - Build-time: `REBRICKABLE_API_KEY` env var → `Scripts/generate-api-config.sh` → `Configuration/Generated/GeneratedConfiguration.swift`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,6 +2,16 @@
 
 This document defines the app-wide conventions for MVVM + async/await used throughout Brixie.
 
+## SwiftUI-Only Architecture
+
+**CRITICAL REQUIREMENT**: Brixie is a pure SwiftUI application that does NOT use UIKit or AppKit.
+
+- **No platform-specific imports**: Only `SwiftUI`, `Foundation`, `SwiftData`, and the `RebrickableLegoAPIClient` are allowed
+- **Device detection**: Use `@Environment(\.horizontalSizeClass)` instead of `UIDevice`
+- **Sharing**: Use SwiftUI's `ShareLink` instead of `UIActivityViewController`/`NSSharingServicePicker`
+- **Image loading**: Custom SwiftUI-based solutions or `AsyncImage`, no UIKit/AppKit image types
+- **Platform differences**: Handle via SwiftUI modifiers and environment values, not conditional compilation
+
 ## Layers
 
 - View (SwiftUI)
@@ -35,6 +45,48 @@ This document defines the app-wide conventions for MVVM + async/await used throu
 - ViewModels and Repositories are annotated `@MainActor` to ensure UI-safe state updates.
 - Use `Task { await ... }` in Views when invoking async VM methods from synchronous closures.
 - Use `actor`s only for shared mutable state that crosses isolation boundaries. Most app types are `@MainActor` or value types.
+
+## Observation and State Management
+
+**Observable Pattern**: ViewModels MUST use `@Observable` macro (iOS 17+) for automatic change tracking:
+
+```swift
+@Observable
+@MainActor
+final class LegoSetViewModel {
+    var sets: [LegoSet] = []
+    var isLoading = false
+    var error: BrixieError?
+    
+    func loadSets() async { /* ... */ }
+}
+```
+
+**State Management**: Views MUST use `@State` for ViewModel instances:
+
+```swift
+struct BrowseView: View {
+    @State private var viewModel = LegoSetViewModel()
+    
+    var body: some View {
+        NavigationView {
+            // View automatically observes viewModel changes
+        }
+        .task {
+            await viewModel.loadSets()
+        }
+    }
+}
+```
+
+**Key Benefits**:
+
+- Automatic UI updates when ViewModel properties change
+- No manual `@Published` or `@StateObject` boilerplate
+- Native Swift 6 concurrency support
+- Thread-safe with `@MainActor` annotation
+
+**Migration Note**: Legacy `@ObservableObject`/`@StateObject` patterns should be migrated to `@Observable`/`@State` during refactoring.
 
 ## Error Handling
 

--- a/Brixie/Views/ContentView.swift
+++ b/Brixie/Views/ContentView.swift
@@ -8,10 +8,6 @@
 import SwiftUI
 import SwiftData
 
-#if canImport(UIKit)
-import UIKit
-#endif
-
 /// Main content view with platform-specific navigation
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
@@ -133,13 +129,10 @@ struct ContentView: View {
     
     /// Determines whether to use tab or sidebar navigation
     private var useTabNavigation: Bool {
-        #if os(iOS)
-        // Use tab navigation on iPhone or iPad in compact width
-        return UIDevice.current.userInterfaceIdiom == .phone || horizontalSizeClass == .compact
-        #else
-        // Always use sidebar on macOS and visionOS
-        return false
-        #endif
+        // Use SwiftUI's horizontal size class for responsive navigation
+        // Tab navigation for compact width (iPhone, iPad split view)
+        // Sidebar navigation for regular width (iPad full screen, macOS)
+        return horizontalSizeClass == .compact
     }
     
     /// Returns the appropriate view for the selected tab

--- a/Brixie/Views/SetDetailView.swift
+++ b/Brixie/Views/SetDetailView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct SetDetailView: View {
     let set: LegoSet
-    @State private var showShareSheet = false
     
     var body: some View {
         ScrollView {
@@ -49,13 +48,11 @@ struct SetDetailView: View {
                     .accessibilityIdentifier("setGallery")
                 }
                 
-                Button(action: { showShareSheet = true }) {
+                // Pure SwiftUI sharing using ShareLink (iOS 16+/macOS 13+)
+                ShareLink(item: shareText, preview: SharePreview(set.name)) {
                     Label("Share Set", systemImage: "square.and.arrow.up")
                 }
                 .accessibilityIdentifier("shareButton")
-                .sheet(isPresented: $showShareSheet) {
-                    ActivityView(activityItems: [shareText])
-                }
             }
             .padding()
         }
@@ -66,17 +63,6 @@ struct SetDetailView: View {
         "Check out LEGO set \(set.name) (#\(set.setNumber)), released in \(set.year) with \(set.numParts) parts!"
     }
 }
-
 #Preview {
     SetDetailView(set: LegoSet.example)
-}
-
-// UIKit share sheet wrapper for SwiftUI
-import UIKit
-struct ActivityView: UIViewControllerRepresentable {
-    let activityItems: [Any]
-    func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
-    }
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }


### PR DESCRIPTION
## Overview

This PR refactors Brixie to use a pure SwiftUI architecture by completely removing UIKit and AppKit dependencies across all components.

## Key Changes

### 🏗️ Architecture Updates
- **Complete UIKit/AppKit removal**: All platform-specific imports eliminated
- **Pure SwiftUI components**: All UI components now use only SwiftUI primitives
- **Cross-platform compatibility**: Unified approach using SwiftUI environment values

### 📱 Component Changes
- **AsyncCachedImage**: Rewritten to use pure SwiftUI with temporary file approach for image loading
- **ContentView**: Device detection now uses `@Environment(\.horizontalSizeClass)` instead of `UIDevice`
- **SetDetailView**: Replaced `UIActivityViewController` with SwiftUI's `ShareLink`

### 📚 Documentation Updates
- **ARCHITECTURE.md**: Added comprehensive SwiftUI-only architecture guidelines
- **Copilot Instructions**: Updated to emphasize pure SwiftUI requirements and constraints

## Breaking Changes
- ⚠️ Components now require iOS 16+ for ShareLink functionality
- ⚠️ Removed platform-specific image type dependencies

## Benefits
- ✅ Simplified codebase with no platform-specific conditionals
- ✅ Better maintainability with unified SwiftUI approach
- ✅ Improved cross-platform consistency
- ✅ Future-proof architecture aligned with SwiftUI evolution

## Testing
- [x] Builds successfully on all target platforms
- [x] No compilation errors or warnings
- [x] Architecture documentation updated

This refactoring establishes a solid foundation for future SwiftUI development and ensures consistency across all platforms.